### PR TITLE
Add timezone option

### DIFF
--- a/lib/fluent/plugin/filter_groonga_query_log.rb
+++ b/lib/fluent/plugin/filter_groonga_query_log.rb
@@ -26,7 +26,9 @@ module Fluent
     config_param :slow_response_threshold,  :float,  :default => 0.2
     config_param :flatten,                  :bool,   :default => false
     config_param :flatten_separator,        :string, :default => nil
-    config_param :timezone,                 :string, :default => "utc"
+    config_param :timezone,                 :enum,
+                                            :list => [:utc, :localtime],
+                                            :default => :utc
 
     def configure(conf)
       super
@@ -65,7 +67,7 @@ module Fluent
 
     def format_time(time)
       case @timezone
-      when "localtime"
+      when :localtime
         time.iso8601(6)
       else
         time.utc.iso8601(6)

--- a/test/test_filter_groonga_query_log.rb
+++ b/test/test_filter_groonga_query_log.rb
@@ -40,7 +40,7 @@ class GroongaQueryLogFilterTest < Test::Unit::TestCase
                      :slow_response_threshold  => 0.2,
                      :flatten                  => false,
                      :flatten_separator        => nil,
-                     :timezone                 => "utc",
+                     :timezone                 => :utc,
                    },
                    {
                      :raw_data_column_name     => filter.raw_data_column_name,
@@ -85,7 +85,7 @@ class GroongaQueryLogFilterTest < Test::Unit::TestCase
     test "timezone" do
       driver = create_driver("timezone localtime")
       filter = driver.instance
-      assert_equal("localtime", filter.timezone)
+      assert_equal(:localtime, filter.timezone)
     end
   end
 


### PR DESCRIPTION
The timezone of a parsed query log is UTC in default.
However, there is a case that we want to output local time.
So, we added a timezone option. If we set "localtime" in the timezone option, timezone of the parsed query log is local time.