### PR TITLE
Add time_format option

### DIFF
--- a/lib/fluent/plugin/filter_groonga_query_log.rb
+++ b/lib/fluent/plugin/filter_groonga_query_log.rb
@@ -81,6 +81,8 @@ module Fluent
         else
           format << "%:z"
         end
+      when "sql"
+        format  = "%Y-%m-%d %H:%M:%S.%6N"
       # We can add more shotcuts here: when "..."
       else
         @time_format

--- a/lib/fluent/plugin/filter_groonga_query_log.rb
+++ b/lib/fluent/plugin/filter_groonga_query_log.rb
@@ -75,15 +75,14 @@ module Fluent
     def resolve_time_format
       case @time_format
       when "iso8601"
-        format  = "%Y-%m-%dT%H:%M:%S.%6N"
+        format = "%Y-%m-%dT%H:%M:%S.%6N"
         if @timezone == :utc
           format << "Z"
         else
           format << "%:z"
         end
       when "sql"
-        format  = "%Y-%m-%d %H:%M:%S.%6N"
-      # We can add more shotcuts here: when "..."
+        format = "%Y-%m-%d %H:%M:%S.%6N"
       else
         @time_format
       end

--- a/lib/fluent/plugin/filter_groonga_query_log.rb
+++ b/lib/fluent/plugin/filter_groonga_query_log.rb
@@ -69,10 +69,10 @@ module Fluent
 
     def format_time(time)
       time.utc if @timezone == :utc
-      time.strftime(format)
+      time.strftime(resolve_time_format)
     end
 
-    def format
+    def resolve_time_format
       case @time_format
       when "iso8601"
         format  = "%Y-%m-%dT%H:%M:%S.%6N"

--- a/test/test_filter_groonga_query_log.rb
+++ b/test/test_filter_groonga_query_log.rb
@@ -391,6 +391,54 @@ class GroongaQueryLogFilterTest < Test::Unit::TestCase
     end
 
     sub_test_case "time_format" do
+      test "sql" do
+        messages = [
+          "2015-08-12 15:50:40.130990|0x7fb07d113da0|>/d/select?table=Entries&match_columns=name&query=xml",
+          "2015-08-12 15:50:40.296165|0x7fb07d113da0|:000000165177838 filter(10)",
+          "2015-08-12 15:50:40.296172|0x7fb07d113da0|:000000165184723 select(10)",
+          "2015-08-12 15:50:41.228129|0x7fb07d113da0|:000001097153433 output(10)",
+          "2015-08-12 15:50:41.228317|0x7fb07d113da0|<000001097334986 rc=0",
+        ]
+        statistic = {
+          "start_time"  => "2015-08-12 06:50:40.130990",
+          "last_time"   => "2015-08-12 06:50:41.228324",
+          "elapsed"     => 1.0973349860000001,
+          "return_code" => 0,
+          "slow"        => true,
+          "command" => {
+            "raw" => "/d/select?table=Entries&match_columns=name&query=xml",
+            "name" => "select",
+            "parameters" => [
+              {"key" => :table,         "value" => "Entries"},
+              {"key" => :match_columns, "value" => "name"},
+              {"key" => :query,         "value" => "xml"},
+            ],
+          },
+          "operations" => [
+            {
+              "context"          => "query: xml",
+              "name"             => "filter",
+              "relative_elapsed" => 0.165177838,
+              "slow"             => true,
+            },
+            {
+              "context"          => nil,
+              "name"             => "select",
+              "relative_elapsed" => 6.884999999999999e-06,
+              "slow"             => false,
+            },
+            {
+              "context"          => nil,
+              "name"             => "output",
+              "relative_elapsed" => 0.93196871,
+              "slow"             => true,
+            },
+          ],
+        }
+        event_stream = emit("time_format sql", messages)
+        assert_equal([[@now, statistic]], event_stream.to_a)
+      end
+
       test "string" do
         messages = [
           "2015-08-12 15:50:40.130990|0x7fb07d113da0|>/d/select?table=Entries&match_columns=name&query=xml",
@@ -438,57 +486,108 @@ class GroongaQueryLogFilterTest < Test::Unit::TestCase
         event_stream = emit("time_format %Y-%m-%d %H:%M:%S.%6N", messages)
         assert_equal([[@now, statistic]], event_stream.to_a)
       end
-    end
 
-    test "timezone and time_format" do
-      messages = [
-        "2015-08-12 15:50:40.130990|0x7fb07d113da0|>/d/select?table=Entries&match_columns=name&query=xml",
-        "2015-08-12 15:50:40.296165|0x7fb07d113da0|:000000165177838 filter(10)",
-        "2015-08-12 15:50:40.296172|0x7fb07d113da0|:000000165184723 select(10)",
-        "2015-08-12 15:50:41.228129|0x7fb07d113da0|:000001097153433 output(10)",
-        "2015-08-12 15:50:41.228317|0x7fb07d113da0|<000001097334986 rc=0",
-      ]
-      statistic = {
-        "start_time"  => "2015-08-12 15:50:40.130990",
-        "last_time"   => "2015-08-12 15:50:41.228324",
-        "elapsed"     => 1.0973349860000001,
-        "return_code" => 0,
-        "slow"        => true,
-        "command" => {
-          "raw" => "/d/select?table=Entries&match_columns=name&query=xml",
-          "name" => "select",
-          "parameters" => [
-            {"key" => :table,         "value" => "Entries"},
-            {"key" => :match_columns, "value" => "name"},
-            {"key" => :query,         "value" => "xml"},
+      test "sql and localtime" do
+        messages = [
+          "2015-08-12 15:50:40.130990|0x7fb07d113da0|>/d/select?table=Entries&match_columns=name&query=xml",
+          "2015-08-12 15:50:40.296165|0x7fb07d113da0|:000000165177838 filter(10)",
+          "2015-08-12 15:50:40.296172|0x7fb07d113da0|:000000165184723 select(10)",
+          "2015-08-12 15:50:41.228129|0x7fb07d113da0|:000001097153433 output(10)",
+          "2015-08-12 15:50:41.228317|0x7fb07d113da0|<000001097334986 rc=0",
+        ]
+        statistic = {
+          "start_time"  => "2015-08-12 15:50:40.130990",
+          "last_time"   => "2015-08-12 15:50:41.228324",
+          "elapsed"     => 1.0973349860000001,
+          "return_code" => 0,
+          "slow"        => true,
+          "command" => {
+            "raw" => "/d/select?table=Entries&match_columns=name&query=xml",
+            "name" => "select",
+            "parameters" => [
+              {"key" => :table,         "value" => "Entries"},
+              {"key" => :match_columns, "value" => "name"},
+              {"key" => :query,         "value" => "xml"},
+            ],
+          },
+          "operations" => [
+            {
+              "context"          => "query: xml",
+              "name"             => "filter",
+              "relative_elapsed" => 0.165177838,
+              "slow"             => true,
+            },
+            {
+              "context"          => nil,
+              "name"             => "select",
+              "relative_elapsed" => 6.884999999999999e-06,
+              "slow"             => false,
+            },
+            {
+              "context"          => nil,
+              "name"             => "output",
+              "relative_elapsed" => 0.93196871,
+              "slow"             => true,
+            },
           ],
-        },
-        "operations" => [
-          {
-            "context"          => "query: xml",
-            "name"             => "filter",
-            "relative_elapsed" => 0.165177838,
-            "slow"             => true,
+        }
+        event_stream = emit(<<-CONFIGURATION, messages)
+          timezone localtime
+          time_format sql
+        CONFIGURATION
+        assert_equal([[@now, statistic]], event_stream.to_a)
+      end
+
+      test "string and localtime" do
+        messages = [
+          "2015-08-12 15:50:40.130990|0x7fb07d113da0|>/d/select?table=Entries&match_columns=name&query=xml",
+          "2015-08-12 15:50:40.296165|0x7fb07d113da0|:000000165177838 filter(10)",
+          "2015-08-12 15:50:40.296172|0x7fb07d113da0|:000000165184723 select(10)",
+          "2015-08-12 15:50:41.228129|0x7fb07d113da0|:000001097153433 output(10)",
+          "2015-08-12 15:50:41.228317|0x7fb07d113da0|<000001097334986 rc=0",
+        ]
+        statistic = {
+          "start_time"  => "2015-08-12 15:50:40.130990",
+          "last_time"   => "2015-08-12 15:50:41.228324",
+          "elapsed"     => 1.0973349860000001,
+          "return_code" => 0,
+          "slow"        => true,
+          "command" => {
+            "raw" => "/d/select?table=Entries&match_columns=name&query=xml",
+            "name" => "select",
+            "parameters" => [
+              {"key" => :table,         "value" => "Entries"},
+              {"key" => :match_columns, "value" => "name"},
+              {"key" => :query,         "value" => "xml"},
+            ],
           },
-          {
-            "context"          => nil,
-            "name"             => "select",
-            "relative_elapsed" => 6.884999999999999e-06,
-            "slow"             => false,
-          },
-          {
-            "context"          => nil,
-            "name"             => "output",
-            "relative_elapsed" => 0.93196871,
-            "slow"             => true,
-          },
-        ],
-      }
-      event_stream = emit(<<-CONFIGURATION, messages)
-        timezone localtime
-        time_format %Y-%m-%d %H:%M:%S.%6N
-      CONFIGURATION
-      assert_equal([[@now, statistic]], event_stream.to_a)
+          "operations" => [
+            {
+              "context"          => "query: xml",
+              "name"             => "filter",
+              "relative_elapsed" => 0.165177838,
+              "slow"             => true,
+            },
+            {
+              "context"          => nil,
+              "name"             => "select",
+              "relative_elapsed" => 6.884999999999999e-06,
+              "slow"             => false,
+            },
+            {
+              "context"          => nil,
+              "name"             => "output",
+              "relative_elapsed" => 0.93196871,
+              "slow"             => true,
+            },
+          ],
+        }
+        event_stream = emit(<<-CONFIGURATION, messages)
+          timezone localtime
+          time_format %Y-%m-%d %H:%M:%S.%6N
+        CONFIGURATION
+        assert_equal([[@now, statistic]], event_stream.to_a)
+      end
     end
   end
 end

--- a/test/test_filter_groonga_query_log.rb
+++ b/test/test_filter_groonga_query_log.rb
@@ -84,13 +84,13 @@ class GroongaQueryLogFilterTest < Test::Unit::TestCase
       assert_equal("_", filter.flatten_separator)
     end
 
-    test "localtime" do
+    test "timezone" do
       driver = create_driver("timezone localtime")
       filter = driver.instance
       assert_equal(:localtime, filter.timezone)
     end
 
-    test "string" do
+    test "time_format" do
       driver = create_driver("time_format %Y-%m-%d %H:%M:%S.%6N")
       filter = driver.instance
       assert_equal("%Y-%m-%d %H:%M:%S.%6N", filter.time_format)

--- a/test/test_filter_groonga_query_log.rb
+++ b/test/test_filter_groonga_query_log.rb
@@ -41,7 +41,7 @@ class GroongaQueryLogFilterTest < Test::Unit::TestCase
                      :flatten                  => false,
                      :flatten_separator        => nil,
                      :timezone                 => :utc,
-                     :time_format              => :iso8601,
+                     :time_format              => "iso8601",
                    },
                    {
                      :raw_data_column_name     => filter.raw_data_column_name,
@@ -90,10 +90,10 @@ class GroongaQueryLogFilterTest < Test::Unit::TestCase
       assert_equal(:localtime, filter.timezone)
     end
 
-    test "datetime" do
-      driver = create_driver("time_format datetime")
+    test "string" do
+      driver = create_driver("time_format %Y-%m-%d %H:%M:%S.%6N")
       filter = driver.instance
-      assert_equal(:datetime, filter.time_format)
+      assert_equal("%Y-%m-%d %H:%M:%S.%6N", filter.time_format)
     end
   end
 
@@ -340,103 +340,107 @@ class GroongaQueryLogFilterTest < Test::Unit::TestCase
       assert_equal([[@now, statistics]], event_stream.to_a)
     end
 
-    test "localtime_of_timezone" do
-      messages = [
-        "2015-08-12 15:50:40.130990|0x7fb07d113da0|>/d/select?table=Entries&match_columns=name&query=xml",
-        "2015-08-12 15:50:40.296165|0x7fb07d113da0|:000000165177838 filter(10)",
-        "2015-08-12 15:50:40.296172|0x7fb07d113da0|:000000165184723 select(10)",
-        "2015-08-12 15:50:41.228129|0x7fb07d113da0|:000001097153433 output(10)",
-        "2015-08-12 15:50:41.228317|0x7fb07d113da0|<000001097334986 rc=0",
-      ]
-      statistic = {
-        "start_time"  => "2015-08-12T15:50:40.130990+09:00",
-        "last_time"   => "2015-08-12T15:50:41.228324+09:00",
-        "elapsed"     => 1.0973349860000001,
-        "return_code" => 0,
-        "slow"        => true,
-        "command" => {
-          "raw" => "/d/select?table=Entries&match_columns=name&query=xml",
-          "name" => "select",
-          "parameters" => [
-            {"key" => :table,         "value" => "Entries"},
-            {"key" => :match_columns, "value" => "name"},
-            {"key" => :query,         "value" => "xml"},
+    sub_test_case "timezone" do
+      test "localtime" do
+        messages = [
+          "2015-08-12 15:50:40.130990|0x7fb07d113da0|>/d/select?table=Entries&match_columns=name&query=xml",
+          "2015-08-12 15:50:40.296165|0x7fb07d113da0|:000000165177838 filter(10)",
+          "2015-08-12 15:50:40.296172|0x7fb07d113da0|:000000165184723 select(10)",
+          "2015-08-12 15:50:41.228129|0x7fb07d113da0|:000001097153433 output(10)",
+          "2015-08-12 15:50:41.228317|0x7fb07d113da0|<000001097334986 rc=0",
+        ]
+        statistic = {
+          "start_time"  => "2015-08-12T15:50:40.130990+09:00",
+          "last_time"   => "2015-08-12T15:50:41.228324+09:00",
+          "elapsed"     => 1.0973349860000001,
+          "return_code" => 0,
+          "slow"        => true,
+          "command" => {
+            "raw" => "/d/select?table=Entries&match_columns=name&query=xml",
+            "name" => "select",
+            "parameters" => [
+              {"key" => :table,         "value" => "Entries"},
+              {"key" => :match_columns, "value" => "name"},
+              {"key" => :query,         "value" => "xml"},
+            ],
+          },
+          "operations" => [
+            {
+              "context"          => "query: xml",
+              "name"             => "filter",
+              "relative_elapsed" => 0.165177838,
+              "slow"             => true,
+            },
+            {
+              "context"          => nil,
+              "name"             => "select",
+              "relative_elapsed" => 6.884999999999999e-06,
+              "slow"             => false,
+            },
+            {
+              "context"          => nil,
+              "name"             => "output",
+              "relative_elapsed" => 0.93196871,
+              "slow"             => true,
+            },
           ],
-        },
-        "operations" => [
-          {
-            "context"          => "query: xml",
-            "name"             => "filter",
-            "relative_elapsed" => 0.165177838,
-            "slow"             => true,
-          },
-          {
-            "context"          => nil,
-            "name"             => "select",
-            "relative_elapsed" => 6.884999999999999e-06,
-            "slow"             => false,
-          },
-          {
-            "context"          => nil,
-            "name"             => "output",
-            "relative_elapsed" => 0.93196871,
-            "slow"             => true,
-          },
-        ],
-      }
-      event_stream = emit("timezone localtime", messages)
-      assert_equal([[@now, statistic]], event_stream.to_a)
+        }
+        event_stream = emit("timezone localtime", messages)
+        assert_equal([[@now, statistic]], event_stream.to_a)
+      end
     end
 
-    test "datetime_of_time_format" do
-      messages = [
-        "2015-08-12 15:50:40.130990|0x7fb07d113da0|>/d/select?table=Entries&match_columns=name&query=xml",
-        "2015-08-12 15:50:40.296165|0x7fb07d113da0|:000000165177838 filter(10)",
-        "2015-08-12 15:50:40.296172|0x7fb07d113da0|:000000165184723 select(10)",
-        "2015-08-12 15:50:41.228129|0x7fb07d113da0|:000001097153433 output(10)",
-        "2015-08-12 15:50:41.228317|0x7fb07d113da0|<000001097334986 rc=0",
-      ]
-      statistic = {
-        "start_time"  => "2015-08-12 06:50:40.130990",
-        "last_time"   => "2015-08-12 06:50:41.228324",
-        "elapsed"     => 1.0973349860000001,
-        "return_code" => 0,
-        "slow"        => true,
-        "command" => {
-          "raw" => "/d/select?table=Entries&match_columns=name&query=xml",
-          "name" => "select",
-          "parameters" => [
-            {"key" => :table,         "value" => "Entries"},
-            {"key" => :match_columns, "value" => "name"},
-            {"key" => :query,         "value" => "xml"},
+    sub_test_case "time_format" do
+      test "string" do
+        messages = [
+          "2015-08-12 15:50:40.130990|0x7fb07d113da0|>/d/select?table=Entries&match_columns=name&query=xml",
+          "2015-08-12 15:50:40.296165|0x7fb07d113da0|:000000165177838 filter(10)",
+          "2015-08-12 15:50:40.296172|0x7fb07d113da0|:000000165184723 select(10)",
+          "2015-08-12 15:50:41.228129|0x7fb07d113da0|:000001097153433 output(10)",
+          "2015-08-12 15:50:41.228317|0x7fb07d113da0|<000001097334986 rc=0",
+        ]
+        statistic = {
+          "start_time"  => "2015-08-12 06:50:40.130990",
+          "last_time"   => "2015-08-12 06:50:41.228324",
+          "elapsed"     => 1.0973349860000001,
+          "return_code" => 0,
+          "slow"        => true,
+          "command" => {
+            "raw" => "/d/select?table=Entries&match_columns=name&query=xml",
+            "name" => "select",
+            "parameters" => [
+              {"key" => :table,         "value" => "Entries"},
+              {"key" => :match_columns, "value" => "name"},
+              {"key" => :query,         "value" => "xml"},
+            ],
+          },
+          "operations" => [
+            {
+              "context"          => "query: xml",
+              "name"             => "filter",
+              "relative_elapsed" => 0.165177838,
+              "slow"             => true,
+            },
+            {
+              "context"          => nil,
+              "name"             => "select",
+              "relative_elapsed" => 6.884999999999999e-06,
+              "slow"             => false,
+            },
+            {
+              "context"          => nil,
+              "name"             => "output",
+              "relative_elapsed" => 0.93196871,
+              "slow"             => true,
+            },
           ],
-        },
-        "operations" => [
-          {
-            "context"          => "query: xml",
-            "name"             => "filter",
-            "relative_elapsed" => 0.165177838,
-            "slow"             => true,
-          },
-          {
-            "context"          => nil,
-            "name"             => "select",
-            "relative_elapsed" => 6.884999999999999e-06,
-            "slow"             => false,
-          },
-          {
-            "context"          => nil,
-            "name"             => "output",
-            "relative_elapsed" => 0.93196871,
-            "slow"             => true,
-          },
-        ],
-      }
-      event_stream = emit("time_format datetime", messages)
-      assert_equal([[@now, statistic]], event_stream.to_a)
+        }
+        event_stream = emit("time_format %Y-%m-%d %H:%M:%S.%6N", messages)
+        assert_equal([[@now, statistic]], event_stream.to_a)
+      end
     end
 
-    test "time_zone_is_localtime_and_format_is_datetime" do
+    test "timezone time_format" do
       messages = [
         "2015-08-12 15:50:40.130990|0x7fb07d113da0|>/d/select?table=Entries&match_columns=name&query=xml",
         "2015-08-12 15:50:40.296165|0x7fb07d113da0|:000000165177838 filter(10)",
@@ -482,7 +486,7 @@ class GroongaQueryLogFilterTest < Test::Unit::TestCase
       }
       event_stream = emit(<<-CONFIGURATION, messages)
         timezone localtime
-        time_format datetime
+        time_format %Y-%m-%d %H:%M:%S.%6N
       CONFIGURATION
       assert_equal([[@now, statistic]], event_stream.to_a)
     end

--- a/test/test_filter_groonga_query_log.rb
+++ b/test/test_filter_groonga_query_log.rb
@@ -440,7 +440,7 @@ class GroongaQueryLogFilterTest < Test::Unit::TestCase
       end
     end
 
-    test "timezone time_format" do
+    test "timezone and time_format" do
       messages = [
         "2015-08-12 15:50:40.130990|0x7fb07d113da0|>/d/select?table=Entries&match_columns=name&query=xml",
         "2015-08-12 15:50:40.296165|0x7fb07d113da0|:000000165177838 filter(10)",


### PR DESCRIPTION
The timestamp format of a parsed query log is ISO8601 in default.
However, there is a case that we want to modify the output format.
So, we added a `time_format` option. If we set `datetime` in the `time_format` option, timestamp format of the parsed query log is "YYYY-MM-DD-SS.mmmmmm".

Currently, we can set value in time_format option only below.

* `iso8601`: The timestamp format is ISO8601.
* `datetime`: The timestamp format is "YYYY-MM-DD-SS.mmmmmm".

The default value is `iso8601`.