### PR TITLE
Avoid unexpected NoMethodError

### DIFF
--- a/lib/fluent/plugin/filter_groonga_query_log.rb
+++ b/lib/fluent/plugin/filter_groonga_query_log.rb
@@ -49,6 +49,7 @@ module Fluent
         raw_data = record[@raw_data_column_name]
         next if raw_data.nil?
         @parser.parse(raw_data) do |statistic|
+          next if statistic.command.nil?
           statistic_record = create_record(statistic)
           statistics_event_stream.add(time, statistic_record)
         end

--- a/test/test_filter_groonga_query_log.rb
+++ b/test/test_filter_groonga_query_log.rb
@@ -588,6 +588,16 @@ class GroongaQueryLogFilterTest < Test::Unit::TestCase
         CONFIGURATION
         assert_equal([[@now, statistic]], event_stream.to_a)
       end
+
+      test "document root" do
+        messages = [
+          "2015-08-12 15:50:40.130990|0x7fb07d113da0|>/",
+          "2015-08-12 15:50:41.228317|0x7fb07d113da0|<000001097334986 rc=0",
+        ]
+        event_stream = emit(<<-CONFIGURATION, messages)
+        CONFIGURATION
+        assert_equal([], event_stream.to_a)
+      end
     end
   end
 end


### PR DESCRIPTION
When access to document root "/" is recorded, statistic.command
is set to nil. It causes the following error when creating
record because create_record call command.arguments internally.

  NoMethodError: undefined method `arguments' for nil:NilClass